### PR TITLE
KB-12671 - NPE issue fix for secretKey and fixed navigation issue in OTP expired scenario

### DIFF
--- a/keycloak/sms-provider/dependency-reduced-pom.xml
+++ b/keycloak/sms-provider/dependency-reduced-pom.xml
@@ -33,16 +33,28 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.2.5</version>
         <configuration>
-          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED
-						--add-opens java.base/java.util=ALL-UNNAMED
-						--add-opens java.base/java.lang.reflect=ALL-UNNAMED
-						--add-opens java.base/java.text=ALL-UNNAMED
-						--add-opens java.desktop/java.awt.font=ALL-UNNAMED
-						--add-opens java.base/sun.nio.ch=ALL-UNNAMED</argLine>
+          <argLine>${surefire.argLine}</argLine>
         </configuration>
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>java8</id>
+      <properties />
+    </profile>
+    <profile>
+      <id>java9-plus</id>
+      <properties>
+        <surefire.argLine>--add-opens java.base/java.lang=ALL-UNNAMED
+					--add-opens java.base/java.util=ALL-UNNAMED
+					--add-opens java.base/java.lang.reflect=ALL-UNNAMED
+					--add-opens java.base/java.text=ALL-UNNAMED
+					--add-opens java.desktop/java.awt.font=ALL-UNNAMED
+					--add-opens java.base/sun.nio.ch=ALL-UNNAMED</surefire.argLine>
+      </properties>
+    </profile>
+  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.keycloak</groupId>

--- a/keycloak/sms-provider/dependency-reduced-pom.xml
+++ b/keycloak/sms-provider/dependency-reduced-pom.xml
@@ -29,6 +29,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+        <configuration>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED
+						--add-opens java.base/java.util=ALL-UNNAMED
+						--add-opens java.base/java.lang.reflect=ALL-UNNAMED
+						--add-opens java.base/java.text=ALL-UNNAMED
+						--add-opens java.desktop/java.awt.font=ALL-UNNAMED
+						--add-opens java.base/sun.nio.ch=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>
@@ -145,6 +157,60 @@
       <artifactId>junit</artifactId>
       <version>4.12</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>hamcrest-core</artifactId>
+          <groupId>org.hamcrest</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>powermock-module-junit4-common</artifactId>
+          <groupId>org.powermock</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hamcrest-core</artifactId>
+          <groupId>org.hamcrest</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>powermock-api-support</artifactId>
+          <groupId>org.powermock</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.28.2</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>byte-buddy</artifactId>
+          <groupId>net.bytebuddy</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>byte-buddy-agent</artifactId>
+          <groupId>net.bytebuddy</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>objenesis</artifactId>
+          <groupId>org.objenesis</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
   <properties>

--- a/keycloak/sms-provider/pom.xml
+++ b/keycloak/sms-provider/pom.xml
@@ -34,10 +34,25 @@
 									<exclude>org.apache.maven:lib:tests</exclude>
 								</excludes>
 							</artifactSet>
-							
+
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.2.5</version>
+				<configuration>
+					<argLine>
+						--add-opens java.base/java.lang=ALL-UNNAMED
+						--add-opens java.base/java.util=ALL-UNNAMED
+						--add-opens java.base/java.lang.reflect=ALL-UNNAMED
+						--add-opens java.base/java.text=ALL-UNNAMED
+						--add-opens java.desktop/java.awt.font=ALL-UNNAMED
+						--add-opens java.base/sun.nio.ch=ALL-UNNAMED
+					</argLine>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>
@@ -103,22 +118,24 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.0</version>
-		</dependency>
-		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
-			<version>1.6.5</version>
-			<!--<scope>test</scope> -->
+			<version>2.0.9</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-mockito</artifactId>
-			<version>1.6.5</version>
-			<!--<scope>test</scope> -->
+			<artifactId>powermock-api-mockito2</artifactId>
+			<version>2.0.9</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.28.2</version>
+			<scope>test</scope>
 		</dependency>
 
 	

--- a/keycloak/sms-provider/pom.xml
+++ b/keycloak/sms-provider/pom.xml
@@ -44,18 +44,43 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.2.5</version>
 				<configuration>
-					<argLine>
-						--add-opens java.base/java.lang=ALL-UNNAMED
-						--add-opens java.base/java.util=ALL-UNNAMED
-						--add-opens java.base/java.lang.reflect=ALL-UNNAMED
-						--add-opens java.base/java.text=ALL-UNNAMED
-						--add-opens java.desktop/java.awt.font=ALL-UNNAMED
-						--add-opens java.base/sun.nio.ch=ALL-UNNAMED
-					</argLine>
+					<argLine>${surefire.argLine}</argLine>
 				</configuration>
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<!-- Profile for Java 8 (no add-opens needed) -->
+		<profile>
+			<id>java8</id>
+			<activation>
+				<jdk>1.8</jdk>
+			</activation>
+			<properties>
+				<surefire.argLine></surefire.argLine>
+			</properties>
+		</profile>
+
+		<!-- Profile for Java 9+ (add-opens required for PowerMock) -->
+		<profile>
+			<id>java9-plus</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<surefire.argLine>
+					--add-opens java.base/java.lang=ALL-UNNAMED
+					--add-opens java.base/java.util=ALL-UNNAMED
+					--add-opens java.base/java.lang.reflect=ALL-UNNAMED
+					--add-opens java.base/java.text=ALL-UNNAMED
+					--add-opens java.desktop/java.awt.font=ALL-UNNAMED
+					--add-opens java.base/sun.nio.ch=ALL-UNNAMED
+				</surefire.argLine>
+			</properties>
+		</profile>
+	</profiles>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.keycloak</groupId>

--- a/keycloak/sms-provider/src/main/java/org/sunbird/keycloak/login/PasswordAndOtpAuthenticator.java
+++ b/keycloak/sms-provider/src/main/java/org/sunbird/keycloak/login/PasswordAndOtpAuthenticator.java
@@ -164,11 +164,16 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 	private void authenticateOtp(AuthenticationFlowContext context) {
 		CODE_STATUS status = validateCode(context);
 		if (status == CODE_STATUS.VALID) {
-			logger.info("Validation of username + password is successful... ");
+			logger.info("Validation of Username + OTP is successful... ");
 			context.getAuthenticationSession().removeAuthNote(Constants.SESSION_OTP_CODE);
 			context.success();
 		} else if (status == CODE_STATUS.EXPIRED) {
-			goErrorPage(context, Constants.PAGE_INPUT_OTP, Constants.OTP_EXPIRED);
+			// OTP expired - clear session data and redirect to login page
+			context.getAuthenticationSession().removeAuthNote(Constants.SESSION_OTP_CODE);
+			context.getAuthenticationSession().removeAuthNote(Constants.SESSION_OTP_EXPIRE_TIME);
+			context.getAuthenticationSession().removeAuthNote(Constants.ATTEMPTED_EMAIL_OR_MOBILE_NUMBER);
+			context.getEvent().getEvent().setError(Constants.OTP_EXPIRED);
+			goErrorPage(context, Constants.OTP_EXPIRED);
 		} else {
 			goErrorPage(context, Constants.PAGE_INPUT_OTP, Constants.INVALID_OTP_ENTERED);
 		}
@@ -222,6 +227,11 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 				errMsg = "Authentication Error! Please enter your credentials again.";
 				Response diffUsersFoundRes = formsProvider.setError(errMsg).createForm(errorPage);
 				context.failureChallenge(AuthenticationFlowError.USER_CONFLICT, diffUsersFoundRes);
+				break;
+			case Constants.OTP_EXPIRED:
+				errMsg = "OTP has expired. Please request for a new OTP.";
+				Response otpExpiredRes = formsProvider.setError(errMsg).createForm(errorPage);
+				context.failureChallenge(AuthenticationFlowError.EXPIRED_CODE, otpExpiredRes);
 				break;
 			case Errors.EMAIL_IN_USE:
 			case Errors.USERNAME_IN_USE:

--- a/keycloak/sms-provider/src/main/java/org/sunbird/keycloak/login/PasswordAndOtpAuthenticator.java
+++ b/keycloak/sms-provider/src/main/java/org/sunbird/keycloak/login/PasswordAndOtpAuthenticator.java
@@ -175,25 +175,15 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 	}
 
 	private void goErrorPage(AuthenticationFlowContext context, String message) {
-		String secretKey = context.getAuthenticationSession().getAuthNote(Constants.SECRET_KEY);
-		if (StringUtils.isBlank(secretKey)) {
-			// Generate the secret key
-			secretKey = generateSecretKey();
-			logger.info("Generated new secret key.");
-		}
-		
-		logger.debug("OtpSmsFormAuthenticator::goErrorPage: message: " + message + ", keyValue: " + secretKey);
+		logger.debug("OtpSmsFormAuthenticator::goErrorPage: message: " + message);
 
-		// Store the secret key as an authentication session note
-		context.getAuthenticationSession().setAuthNote(Constants.SECRET_KEY, secretKey);
-		LoginFormsProvider formsProvider = context.form();
-		formsProvider.setAttribute(Constants.SECRET_KEY, secretKey);
+		LoginFormsProvider formsProvider = getLoginFormsProviderWithSecretKey(context);
 
 		// Set the default error page
 		String errorPage = Constants.LOGIN_PAGE;
 
 		// Check if authNote is blank or equals EC_LOGIN, then set error page to EC_LOGIN_PAGE
-		if (StringUtils.isNotBlank(context.getAuthenticationSession().getAuthNote(Constants.AUTH_NOTE_LOGIN_PAGE)) && 
+		if (StringUtils.isNotBlank(context.getAuthenticationSession().getAuthNote(Constants.AUTH_NOTE_LOGIN_PAGE)) &&
 		        (Constants.EC_LOGIN_PAGE.equals(context.getAuthenticationSession().getAuthNote(Constants.AUTH_NOTE_LOGIN_PAGE)))) {
 			errorPage = Constants.EC_LOGIN_PAGE;
 		}
@@ -221,7 +211,7 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 				Response tempDisabledRes = formsProvider.setError(errMsg).createForm(errorPage);
 				context.failureChallenge(AuthenticationFlowError.USER_TEMPORARILY_DISABLED, tempDisabledRes);
 				break;
-			case Errors.DIFFERENT_USER_AUTHENTICATED: 
+			case Errors.DIFFERENT_USER_AUTHENTICATED:
 				errMsg = "Authentication Error! Please enter your credentials again.";
 				Response diffUsersFoundRes = formsProvider.setError(errMsg).createForm(errorPage);
 				context.failureChallenge(AuthenticationFlowError.USER_CONFLICT, diffUsersFoundRes);
@@ -239,17 +229,19 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 
 	private void goErrorPage(AuthenticationFlowContext context, String page, String message) {
 		logger.info("OtpSmsFormAuthenticator::goErrorPage: message: " + message + ", page: " + page);
-		Response challenge = context.form().setError(message).createForm(page);
+		LoginFormsProvider formsProvider = getLoginFormsProviderWithSecretKey(context);
+		Response challenge = formsProvider.setError(message).createForm(page);
 		context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challenge);
 	}
 
 	private void goPage(AuthenticationFlowContext context, String page) {
-		context.challenge(context.form().createForm(page));
+		LoginFormsProvider formsProvider = getLoginFormsProviderWithSecretKey(context);
+		context.challenge(formsProvider.createForm(page));
 	}
 
 	private void goPage(AuthenticationFlowContext context, String page, String errorMsg,
 			Map<String, String> attributes) {
-		LoginFormsProvider resForm = context.form();
+		LoginFormsProvider resForm = getLoginFormsProviderWithSecretKey(context);
 		for (Entry<String, String> entry : attributes.entrySet()) {
 			resForm.setAttribute(entry.getKey(), entry.getValue());
 		}
@@ -273,6 +265,9 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 	}
 
 	private UserModel getUserByMobileNumber(AuthenticationFlowContext context, String mobilePhone) {
+		// Ensure secretKey is set before any error handling that might render a form
+		ensureSecretKey(context);
+
 		UserModel user = null;
 		try {
 			user = SunbirdModelUtils.getUserByNameEmailOrPhone(context, mobilePhone);
@@ -291,6 +286,12 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 						Constants.MULTIPLE_USER_ASSOCIATED_WITH_PHONE, AuthenticationFlowError.USER_CONFLICT);
 			}
 
+			return null;
+		}
+
+		// Check if user is null - invalidUser() can render forms, so secretKey must be set
+		if (user == null) {
+			logger.warn("User not found for mobile/email: " + mobilePhone);
 			return null;
 		}
 
@@ -621,6 +622,9 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 
 	public boolean validateUserAndPassword(AuthenticationFlowContext context,
 			MultivaluedMap<String, String> inputData) {
+		// Ensure secretKey is set before any validation that might render an error form
+		ensureSecretKey(context);
+
 		String username = inputData.getFirst(AuthenticationManager.FORM_USERNAME);
 		if (username == null) {
 			context.getEvent().error(Errors.USER_NOT_FOUND);
@@ -724,5 +728,34 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 			logger.error("PasswordAndOtpAuthenticator:: Exception while decrypting password. Exception: ", e);
 			throw new RuntimeException("Error while decrypting password", e);
 		}
+	}
+
+	/**
+	 * Ensures secretKey exists in the authentication session. Generates a new one if missing.
+	 * This prevents NullPointerException in FreeMarker templates when forms are rendered.
+	 *
+	 * @param context The authentication flow context
+	 */
+	private void ensureSecretKey(AuthenticationFlowContext context) {
+		if (StringUtils.isBlank(context.getAuthenticationSession().getAuthNote(Constants.SECRET_KEY))) {
+			context.getAuthenticationSession().setAuthNote(Constants.SECRET_KEY, generateSecretKey());
+			logger.info("Generated new secret key.");
+		}
+	}
+
+	/**
+	 * Ensures secretKey is available in the authentication session and returns a LoginFormsProvider
+	 * with the secretKey attribute set. This prevents NullPointerException in FreeMarker templates.
+	 *
+	 * @param context The authentication flow context
+	 * @return LoginFormsProvider with secretKey attribute set
+	 */
+	private LoginFormsProvider getLoginFormsProviderWithSecretKey(AuthenticationFlowContext context) {
+		ensureSecretKey(context);
+		LoginFormsProvider formsProvider = context.form();
+		formsProvider.setAttribute(Constants.SECRET_KEY, 
+			context.getAuthenticationSession().getAuthNote(Constants.SECRET_KEY)
+		);
+		return formsProvider;
 	}
 }

--- a/keycloak/sms-provider/src/main/java/org/sunbird/keycloak/login/PasswordAndOtpAuthenticator.java
+++ b/keycloak/sms-provider/src/main/java/org/sunbird/keycloak/login/PasswordAndOtpAuthenticator.java
@@ -190,6 +190,13 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 
 		String error = context.getEvent().getEvent().getError();
 		String errMsg = "Internal Server Error!";
+
+		// Handle null error case - use empty string to trigger default case
+		if (error == null) {
+			logger.warn("Error code is null, will use default error handling");
+			error = "";
+		}
+
 		switch (error) {
 			case Errors.INVALID_USER_CREDENTIALS:
 				errMsg = "Invalid credentials!";
@@ -305,6 +312,7 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 		String emailOrMobile = getEmailOrMobileNumber(context);
 		UserModel user = getUserByMobileNumber(context, emailOrMobile);
 		if (null == user) {
+			context.getEvent().getEvent().setError(Errors.USER_NOT_FOUND);
 			goErrorPage(context, "Oops, Member not found.");
 			return;
 		}
@@ -326,7 +334,7 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 
 		// Send the key into the User Mobile Phone
 		if (sendOtpByEmailOrSms(context, emailOrMobile, attributes.get(Constants.SESSION_OTP_CODE))) {
-			//SMS is sent successfully, let's save the details in session and return the necessary page.			
+			//SMS is sent successfully, let's save the details in session and return the necessary page.
 			context.getAuthenticationSession().setAuthNote(Constants.SESSION_OTP_CODE, attributes.get(Constants.SESSION_OTP_CODE));
 			context.getAuthenticationSession().setAuthNote(Constants.SESSION_OTP_EXPIRE_TIME, attributes.get(KeycloakSmsAuthenticatorConstants.CONF_PRP_SMS_CODE_TTL));
 			context.getAuthenticationSession().setAuthNote(Constants.ATTEMPTED_EMAIL_OR_MOBILE_NUMBER, emailOrMobile);
@@ -336,6 +344,7 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 			context.setUser(user);
 			goPage(context, Constants.PAGE_INPUT_OTP, StringUtils.EMPTY, attributes);
 		} else {
+			context.getEvent().getEvent().setError("SMS_SEND_FAILED");
 			goErrorPage(context, "Failed to send out SMS. Please contact Administrator.");
 		}
 	}
@@ -353,6 +362,7 @@ public class PasswordAndOtpAuthenticator extends AbstractUsernameFormAuthenticat
 		if (sendOtpByEmailOrSms(context, mobileNumber, attributes.get(Constants.SESSION_OTP_CODE))) {
 			goPage(context, Constants.PAGE_INPUT_OTP);
 		} else {
+			context.getEvent().getEvent().setError("SMS_SEND_FAILED");
 			goErrorPage(context, "Failed to send out SMS. Please contact Administrator.");
 		}
 	}

--- a/keycloak/sms-provider/src/test/java/org/sunbird/keycloak/rest/RequiredActionLinkProviderTest.java
+++ b/keycloak/sms-provider/src/test/java/org/sunbird/keycloak/rest/RequiredActionLinkProviderTest.java
@@ -39,7 +39,9 @@ import org.sunbird.keycloak.utils.Constants;
     KeycloakContext.class, KeycloakModelUtils.class, RealmModel.class, RedirectUtils.class,
     AppAuthManager.class, RequiredActionLinkProvider.class, UriInfo.class, AccessToken.class,
     Access.class, AuthResult.class})
-@PowerMockIgnore({"javax.management.*", "javax.net.ssl.*", "javax.security.*"})
+@PowerMockIgnore({"javax.management.*", "javax.net.ssl.*", "javax.security.*", "javax.crypto.*",
+    "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*",
+    "com.sun.org.apache.xalan.*", "javax.activation.*", "javax.net.*"})
 //@Ignore
 public class RequiredActionLinkProviderTest {
 

--- a/keycloak/sms-provider/src/test/java/org/sunbird/keycloak/storage/spi/UserServiceProviderTest.java
+++ b/keycloak/sms-provider/src/test/java/org/sunbird/keycloak/storage/spi/UserServiceProviderTest.java
@@ -25,7 +25,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({StorageId.class,KeycloakSession.class,ComponentModel.class,UserService.class,
   UserAdapter.class,RealmModel.class,UserModel.class,UserSearchService.class,GroupModel.class})
-@PowerMockIgnore({"javax.management.*", "javax.net.ssl.*", "javax.security.*"})
+@PowerMockIgnore({"javax.management.*", "javax.net.ssl.*", "javax.security.*", "javax.crypto.*",
+    "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*",
+    "com.sun.org.apache.xalan.*", "javax.activation.*", "javax.net.*"})
 public class UserServiceProviderTest {
 
   private static KeycloakSession session = null;


### PR DESCRIPTION
NPE for secretKey is handled and providing proper error messages.
Fixed issue in redirecting when OTP session is expiring. When user enters OTP after it expired, page will navigate back to login page.